### PR TITLE
fixed systemd initialization and db encoding issue

### DIFF
--- a/docker_run_miq
+++ b/docker_run_miq
@@ -1,40 +1,16 @@
 #/bin/bash -x
 
-echo "/usr/sbin/init" 
-/usr/sbin/init 
 
-echo "========= sleep 10" 
-sleep 10 
+echo "========= psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\"" 
+su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\"" 
 
-echo "========= systemctl status  postgresql"
-systemctl status  postgresql
+echo "========= cd /manageiq/manageiq"
+cd /manageiq/manageiq 
 
 
-echo "========= ls -la /var/run/postgresql/"
-ls -la /var/run/postgresql/
+echo "========= ./bin/docker_setup"
+/bin/bash -l -c "./bin/docker_setup"
 
 
-echo "========= systemctl start  postgresql"
-systemctl start  postgresql
-
-echo "========= sleep 10"
-sleep 10
-
-echo "========= ls -la /var/run/postgresql/"
-ls -la /var/run/postgresql/
-
-#sleep 3600
-
-#echo "========= psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\"" 
-#su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\"" 
-
-#echo "========= cd /manageiq/manageiq"
-#cd /manageiq/manageiq 
-
-
-#echo "========= ./bin/docker_setup"
-#/bin/bash -l -c "./bin/docker_setup"
-
-
-#echo "========= bundle exec rake evm:start"
-#/bin/bash -l -c "bundle exec rake evm:start"
+echo "========= bundle exec rake evm:start"
+/bin/bash -l -c "bundle exec rake evm:start"


### PR DESCRIPTION
Current status:
- successfully build image
- docker run will run systemd (postgres & memcached)
- to run manageiq (for debug) need to execute manually docker_run_miq

current failure is on db migration
`== 20160209130938 AddServiceOrderToMiqRequest: migrated (0.0005s) =============

bin/rake: No such file or directory - addr
rake aborted!
NoMethodError: undefined method `[]' for nil:NilClass
/usr/local/rvm/gems/ruby-2.2.3/gems/uuidtools-2.1.5/lib/uuidtools.rb:603:in `block (2 levels) in first_mac'
/usr/local/rvm/gems/ruby-2.2.3/gems/uuidtools-2.1.5/lib/uuidtools.rb:602:in `map'
/usr/local/rvm/gems/ruby-2.2.3/gems/uuidtools-2.1.5/lib/uuidtools.rb:602:in `block in first_mac'
/usr/local/rvm/gems/ruby-2.2.3/gems/uuidtools-2.1.5/lib/uuidtools.rb:608:in `call'
/usr/local/rvm/gems/ruby-2.2.3/gems/uuidtools-2.1.5/lib/uuidtools.rb:608:in `first_mac'
/usr/local/rvm/gems/ruby-2.2.3/gems/uuidtools-2.1.5/lib/uuidtools.rb:634:in `mac_address'
/usr/local/rvm/gems/ruby-2.2.3/gems/uuidtools-2.1.5/lib/uuidtools.rb:242:in `block in timestamp_create'
/usr/local/rvm/gems/ruby-2.2.3/gems/uuidtools-2.1.5/lib/uuidtools.rb:232:in `synchronize'
/usr/local/rvm/gems/ruby-2.2.3/gems/uuidtools-2.1.5/lib/uuidtools.rb:232:in `timestamp_create'
/manageiq/manageiq/gems/pending/util/miq-uuid.rb:16:in `new_guid'
/manageiq/manageiq/app/models/mixins/uuid_mixin.rb:10:in `set_guid'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:382:in `block in make_lambda'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:150:in `call'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:150:in `block (2 levels) in halting_and_conditional'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:770:in `call'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:770:in `block (2 levels) in deprecated_false_terminator'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:769:in `catch'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:769:in `block in deprecated_false_terminator'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:151:in `call'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:151:in `block in halting_and_conditional'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:454:in `call'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:454:in `block in call'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:454:in `each'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:454:in `call'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/callbacks.rb:750:in `_run_validation_callbacks'
/usr/local/rvm/gems/ruby-2.2.3/gems/activemodel-5.0.0.beta2/lib/active_model/validations/callbacks.rb:113:in `run_validations!'
/usr/local/rvm/gems/ruby-2.2.3/gems/activemodel-5.0.0.beta2/lib/active_model/validations.rb:338:in `valid?'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/validations.rb:65:in `valid?'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/validations.rb:82:in `perform_validations'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/validations.rb:50:in `save!'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/transactions.rb:324:in `block in save!'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract/database_statements.rb:228:in `transaction'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/transactions.rb:211:in `transaction'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/transactions.rb:324:in `save!'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/persistence.rb:51:in `create!'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/relation.rb:156:in `block in create!'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/relation.rb:343:in `scoping'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/relation.rb:156:in `create!'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/relation.rb:227:in `find_or_create_by!'
/manageiq/manageiq/app/models/miq_region.rb:116:in `seed'
/manageiq/manageiq/lib/evm_database.rb:68:in `block (2 levels) in seed'
/manageiq/manageiq/lib/evm_database.rb:57:in `each'
/manageiq/manageiq/lib/evm_database.rb:57:in `block in seed'
/manageiq/manageiq/lib/extensions/ar_table_lock.rb:21:in `block (2 levels) in with_lock'
/manageiq/manageiq/lib/extensions/ar_table_lock.rb:21:in `block in with_lock'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `block in transaction'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/transactions.rb:211:in `transaction'
/manageiq/manageiq/lib/extensions/ar_table_lock.rb:15:in `with_lock'
/manageiq/manageiq/lib/evm_database.rb:56:in `seed'
/manageiq/manageiq/db/seeds.rb:8:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/dependencies.rb:296:in `load'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/dependencies.rb:296:in `block in load'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/dependencies.rb:268:in `load_dependency'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/dependencies.rb:296:in `load'
/usr/local/rvm/gems/ruby-2.2.3/gems/railties-5.0.0.beta2/lib/rails/engine.rb:549:in `load_seed'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/tasks/database_tasks.rb:261:in `load_seed'
/usr/local/rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/railties/databases.rake:196:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
`
