### PR TITLE
Container Best Practices Cleanup

### DIFF
--- a/docker_initdb
+++ b/docker_initdb
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Source EVM environment 
+[ -f /etc/default/evm ] &&  . /etc/default/evm
+
+# Check postgres server DB init status, if necessary, initdb, start/enable service and inject MIQ role
+PGDATA=/var/lib/pgsql/data
+PG_CHECK_DB=/usr/bin/postgresql-check-db-dir
+
+if [ -x ${PG_CHECK_DB} ]; then
+
+        echo "== Checking MIQ database status =="
+        ${PG_CHECK_DB} ${PGDATA}
+                if [ $? -eq 0 ]; then
+                        systemctl is-active -q postgresql
+                        if [ $? -ne 0 ]; then
+                                echo "** Postgresql is inactive, starting service"
+                                systemctl start postgresql
+                                test $? -ne 0 && echo "!! Failed to start postgresql service" && exit 1
+                                echo "** Postgresql is now online"
+                        fi
+                        psql --list | grep -q vmdb
+                        test $? -ne 0 && echo "!! MIQ database could not be found, re-run ${BASEDIR}/bin/docker_setup?" && exit 1
+                        echo "** MIQ vmdb was found"
+                        exit 0
+                else
+                        echo "** DB has not been initialized"
+                        echo "** Launching initdb"
+                        su postgres -c "initdb -D ${PGDATA}"
+                        test $? -ne 0 && echo "!! Failed to initdb" && exit 1
+                        echo "** Starting postgresql"
+                        systemctl start postgresql
+                        test $? -ne 0 && echo "!! Failed to start postgresql service" && exit 1
+                        echo "** Creating MIQ role"
+                        su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\""
+                        test $? -ne 0 && echo "!! Failed to inject MIQ root Role" && exit 1
+                        echo "** Starting DB setup"
+                        ${BASEDIR}/bin/docker_setup
+                        test $? -ne 0 && echo "!! ${BASEDIR}/bin/docker_setup failed to run" && exit 1
+                        echo "** MIQ database has been initialized"
+                        systemctl enable -q postgresql
+                        exit 0
+                fi
+else
+        echo "Failed to find ${PG_CHECK_DB}, is postgres server installed?"
+        exit 1
+fi
+}

--- a/evmserver.sh
+++ b/evmserver.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 
-PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+# Source EVM environment 
+[ -f /etc/default/evm ] &&  . /etc/default/evm
 
-# Base MIQ installation dir
-
-BASEDIR=/manageiq
-cd $BASEDIR
-
-# Source RVM environment
-. /etc/profile.d/rvm.sh
+cd ${BASEDIR}
 
 start() {
   bundle exec rake evm:start

--- a/evmserverd.service
+++ b/evmserverd.service
@@ -3,9 +3,10 @@ Description=EVM server daemon
 After=network.target memcached.service postgresql.service
 
 [Service]
-
-ExecStart=/manageiq/bin/evmserver.sh start
-ExecStop=/manageiq/bin/evmserver.sh stop
+TimeoutStartSec=5m
+ExecStartPre=/usr/bin/docker_initdb
+ExecStart=/usr/bin/evmserver.sh start
+ExecStop=/usr/bin/evmserver.sh stop
 Type=forking
 Restart=on-failure
 


### PR DESCRIPTION
- Added persistent data volume for postgres database
- Disabled docker_run database migrate and tests via --nodb --notests
- Migrated all postgres setup calls from Dockerfile to docker_initdb script
- Adjusted systemd unit file to call docker_initdb via PreExecStart (this step now prepares MIQ db)
- Adjusted systemd unit file parameters to allow longer timeouts on service start-up (1m 30s -> 5m)
- Switched ruby environment manager from rvm to chruy, sync with upstream MIQ
- Removed unnecessary VOLUME ["/sys/fs/cgroup"]
- Removed unnecesary systemd cleanups
- Created /etc/default/evm to set correct environment for scripts, sync with upstream MIQ
- Cosmetic re-format of long RUN calls into multi-lines that are easier to read
- Replaced all ";" instances in favor of "&&" (safer and allows better error control)
- Replaced rpm call in favor of yum for EPEL repo installation