### PR TITLE
Atomic labels implementation

### DIFF
--- a/docker-assets/docker_initdb
+++ b/docker-assets/docker_initdb
@@ -11,12 +11,13 @@ if [ -x ${APPLIANCE_PG_CHECKDB} ]; then
         echo "== Checking MIQ database status =="
         ${APPLIANCE_PG_CHECKDB} {APPLIANCE_PG_DATA}
                 if [ $? -eq 0 ]; then
-                        systemctl is-active -q ${APPLIANCE_PG_SERVICE}
+			pg_isready -q
                         if [ $? -ne 0 ]; then
                                 echo "** Postgresql is inactive, starting service"
-                                systemctl start ${APPLIANCE_PG_SERVICE}
+				su postgres -c "pg_ctl -D ${APPLIANCE_PG_DATA} start"
                                 test $? -ne 0 && echo "!! Failed to start postgresql service" && exit 1
                                 echo "** Postgresql is now online"
+				sleep 5
                         fi
                         psql --list | grep -q vmdb
                         test $? -ne 0 && echo "!! MIQ database could not be found, re-run ${BASEDIR}/bin/docker_setup?" && exit 1
@@ -28,11 +29,15 @@ if [ -x ${APPLIANCE_PG_CHECKDB} ]; then
                         su postgres -c "initdb -D ${APPLIANCE_PG_DATA}"
                         test $? -ne 0 && echo "!! Failed to initdb" && exit 1
                         echo "** Starting postgresql"
-                        systemctl start ${APPLIANCE_PG_SERVICE}
+			su postgres -c "pg_ctl -D ${APPLIANCE_PG_DATA} start"
                         test $? -ne 0 && echo "!! Failed to start postgresql service" && exit 1
+			sleep 5
                         echo "** Creating MIQ role"
                         su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\""
                         test $? -ne 0 && echo "!! Failed to inject MIQ root Role" && exit 1
+			# Check if memcached is running, if not start it
+			pidof memcached
+			test $? -ne 0 && /usr/bin/memcached -u memcached -p 11211 -m 64 -c 1024 -l 127.0.0.1 -d
                         echo "** Starting DB setup"
                         ${BASEDIR}/bin/docker_setup
                         test $? -ne 0 && echo "!! ${BASEDIR}/bin/docker_setup failed to run" && exit 1

--- a/docker-assets/evmserverd.service
+++ b/docker-assets/evmserverd.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=EVM server daemon
-After=network.target memcached.service postgresql.service
+After=network.target memcached.service rh-postgresql94-postgresql.service
 
 [Service]
-TimeoutStartSec=5m
+TimeoutStartSec=10m
 ExecStartPre=/usr/bin/docker_initdb
 ExecStart=/usr/bin/evmserver.sh start
 ExecStop=/usr/bin/evmserver.sh stop


### PR DESCRIPTION
- Added suggested LABELS for Atomic use
- Adapted docker_initdb to be more resilient to a systemd-less environment (INSTALL label step)
- Fixed postgres race condition on systemd unit file caused by an old 9.2 release reference on After
- Increased Start timeout on evm systemd unit file to a safer value (laptop build friendly)
- Fixed a minor cleanup on chruby installation

There were no changes in how stock docker runs, this has been validated.

To use/test atomic labels :

atomic install <image>
atomic run <image>
docker inspect <image>

Tested with atomic-1.8-3.gitcc5997a CLI and docker-1.10.2-3.git0f5ac89

Image size remains almost identical :)